### PR TITLE
Update SystemInfo.js

### DIFF
--- a/lib/SystemInfo.js
+++ b/lib/SystemInfo.js
@@ -112,6 +112,10 @@ class SystemInfo extends events.EventEmitter {
     * @return {object} - The extracted info.
     */
   static parseRpiCpuInfo (cpuInfo) {
+    if (cpuInfo == null) {
+      return null
+    }
+    
     const id = /Serial\s*: ([0-9a-f]{16})/.exec(cpuInfo)[1].toUpperCase()
     const revision = parseInt(
       /Revision\s*: ([0-9a-f]{4,})/.exec(cpuInfo)[1], 16


### PR DESCRIPTION
I'm not sure if anyone else is having trouble with this, but usually on startup I see this warning message:

```
[RPi] warning: TypeError: Cannot read properties of null (reading '1')
    at Function.parseRpiCpuInfo (/usr/lib/node_modules/homebridge-rpi/node_modules/homebridge-lib/lib/SystemInfo.js:115:57)
    at SystemInfo.getRpiInfo (/usr/lib/node_modules/homebridge-rpi/node_modules/homebridge-lib/lib/SystemInfo.js:212:23)
    at SystemInfo.init (/usr/lib/node_modules/homebridge-rpi/node_modules/homebridge-lib/lib/SystemInfo.js:175:27)
    at RpiPlatform._main (/usr/lib/node_modules/homebridge-rpi/node_modules/homebridge-lib/lib/Platform.js:222:7)
```

This should hopefully make that message go away, and since `hwInfo` is  automatically set when it catches an error, this shouldn't behave any differently.